### PR TITLE
Allow selection of SPI speed

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -334,7 +334,7 @@ boolean callback_rmdir(SdFile& parentDir, const char *filePathComponent,
 
 
 
-boolean SDClass::begin(uint8_t csPin) {
+boolean SDClass::begin(uint8_t csPin, uint8_t speed) {
   /*
 
     Performs the initialisation required by the sdfatlib library.
@@ -342,7 +342,7 @@ boolean SDClass::begin(uint8_t csPin) {
     Return true if initialization succeeds, false otherwise.
 
    */
-  return card.init(SPI_HALF_SPEED, csPin) &&
+  return card.init(speed, csPin) &&
          volume.init(card) &&
          root.openRoot(volume);
 }

--- a/src/SD.h
+++ b/src/SD.h
@@ -67,7 +67,7 @@ private:
 public:
   // This needs to be called to set up the connection to the SD card
   // before other methods are used.
-  boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN);
+  boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN, uint8_t speed = SPI_HALF_SPEED);
   
   // Open the specified file/directory with the supplied mode (e.g. read or
   // write, etc). Returns a File object for interacting with the file.


### PR DESCRIPTION
This adds a new optional argument to begin to pass in the SD card speed. `SPI_HALF_SPEED` is the default as before.
