### PR TITLE
SPI port selectable from variant

### DIFF
--- a/src/utility/Sd2Card.cpp
+++ b/src/utility/Sd2Card.cpp
@@ -23,6 +23,11 @@
 //------------------------------------------------------------------------------
 #ifndef SOFTWARE_SPI
 #ifdef USE_SPI_LIB
+
+#ifndef SDCARD_SPI
+#define SDCARD_SPI SPI
+#endif
+
 #include <SPI.h>
 static SPISettings settings;
 #endif
@@ -34,7 +39,7 @@ static void spiSend(uint8_t b) {
   while (!(SPSR & (1 << SPIF)))
     ;
 #else
-  SPI.transfer(b);
+  SDCARD_SPI.transfer(b);
 #endif
 }
 /** Receive a byte from the card */
@@ -43,7 +48,7 @@ static  uint8_t spiRec(void) {
   spiSend(0XFF);
   return SPDR;
 #else
-  return SPI.transfer(0xFF);
+  return SDCARD_SPI.transfer(0xFF);
 #endif
 }
 #else  // SOFTWARE_SPI
@@ -164,7 +169,7 @@ void Sd2Card::chipSelectHigh(void) {
 #ifdef USE_SPI_LIB
   if (chip_select_asserted) {
     chip_select_asserted = 0;
-    SPI.endTransaction();
+    SDCARD_SPI.endTransaction();
   }
 #endif
 }
@@ -173,7 +178,7 @@ void Sd2Card::chipSelectLow(void) {
 #ifdef USE_SPI_LIB
   if (!chip_select_asserted) {
     chip_select_asserted = 1;
-    SPI.beginTransaction(settings);
+    SDCARD_SPI.beginTransaction(settings);
   }
 #endif
   digitalWrite(chipSelectPin_, LOW);
@@ -265,18 +270,18 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   // clear double speed
   SPSR &= ~(1 << SPI2X);
 #else // USE_SPI_LIB
-  SPI.begin();
+  SDCARD_SPI.begin();
   settings = SPISettings(250000, MSBFIRST, SPI_MODE0);
 #endif // USE_SPI_LIB
 #endif // SOFTWARE_SPI
 
   // must supply min of 74 clock cycles with CS high.
 #ifdef USE_SPI_LIB
-  SPI.beginTransaction(settings);
+  SDCARD_SPI.beginTransaction(settings);
 #endif
   for (uint8_t i = 0; i < 10; i++) spiSend(0XFF);
 #ifdef USE_SPI_LIB
-  SPI.endTransaction();
+  SDCARD_SPI.endTransaction();
 #endif
 
   chipSelectLow();

--- a/src/utility/Sd2Card.h
+++ b/src/utility/Sd2Card.h
@@ -65,17 +65,27 @@ uint8_t const SPI_QUARTER_SPEED = 2;
  * as an output by init().  An avr processor will not function as an SPI
  * master unless SS is set to output mode.
  */
+#ifndef SDCARD_SS_PIN
 /** The default chip select pin for the SD card is SS. */
 uint8_t const  SD_CHIP_SELECT_PIN = SS;
+#else
+uint8_t const  SD_CHIP_SELECT_PIN = SDCARD_SS_PIN;
+#endif
 
 // The following three pins must not be redefined for hardware SPI,
 // so ensure that they are taken from pins_arduino.h or variant.h, depending on architecture.
+#ifndef SDCARD_MOSI_PIN
 /** SPI Master Out Slave In pin */
 uint8_t const  SPI_MOSI_PIN = MOSI;
 /** SPI Master In Slave Out pin */
 uint8_t const  SPI_MISO_PIN = MISO;
 /** SPI Clock pin */
 uint8_t const  SPI_SCK_PIN = SCK;
+#else
+uint8_t const  SPI_MOSI_PIN = SDCARD_MOSI_PIN;
+uint8_t const  SPI_MISO_PIN = SDCARD_MISO_PIN;
+uint8_t const  SPI_SCK_PIN = SDCARD_SCK_PIN;
+#endif
 
 /** optimize loops for hardware SPI */
 #ifndef USE_SPI_LIB


### PR DESCRIPTION
This PR allows boards to define, from `variant.h`, which pins and SPI devices should be the SD card defaults