### PR TITLE
Add SDClass::end function

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -354,6 +354,12 @@ boolean SDClass::begin(uint32_t clock, uint8_t csPin) {
          root.openRoot(volume);
 }
 
+//call this when a card is removed. It will allow you to insert and initialise a new card.
+void SDClass::end()
+{
+  root.close();
+}
+
 // this little helper is used to traverse paths
 SdFile SDClass::getParentDir(const char *filepath, int *index) {
   // get parent directory

--- a/src/SD.h
+++ b/src/SD.h
@@ -70,6 +70,9 @@ public:
   boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN);
   boolean begin(uint32_t clock, uint8_t csPin);
   
+  //call this when a card is removed. It will allow you to insert and initialise a new card.
+  void end();
+
   // Open the specified file/directory with the supplied mode (e.g. read or
   // write, etc). Returns a File object for interacting with the file.
   // Note that currently only one file can be open at a time.


### PR DESCRIPTION
Call end function to fully de-initialize SD object. Allows you to call
SD.begin again to init a new card.

This change was taken from Adafruit's SD library.

Author: driverblock <rick@embedded-designs.com>