### PR TITLE
Do not expose internal SD.root to sketches with SD.open("/")

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -367,8 +367,10 @@ void SDClass::end()
 // this little helper is used to traverse paths
 SdFile SDClass::getParentDir(const char *filepath, int *index) {
   // get parent directory
-  SdFile d1 = root; // start with the mostparent, root!
+  SdFile d1;
   SdFile d2;
+
+  d1.openRoot(volume); // start with the mostparent, root!
 
   // we'll use the pointers to swap between the two objects
   SdFile *parent = &d1;
@@ -465,20 +467,11 @@ File SDClass::open(const char *filepath, uint8_t mode) {
   if (!parentdir.isOpen())
     return File();
 
-  // there is a special case for the Root directory since its a static dir
-  if (parentdir.isRoot()) {
-    if ( ! file.open(root, filepath, mode)) {
-      // failed to open the file :(
-      return File();
-    }
-    // dont close the root!
-  } else {
-    if ( ! file.open(parentdir, filepath, mode)) {
-      return File();
-    }
-    // close the parent
-    parentdir.close();
+  if ( ! file.open(parentdir, filepath, mode)) {
+    return File();
   }
+  // close the parent
+  parentdir.close();
 
   if ((mode & (O_APPEND | O_WRITE)) == (O_APPEND | O_WRITE))
     file.seekSet(file.fileSize());


### PR DESCRIPTION
Cherry-picked from @PaulStoffregen's: https://github.com/arduino/Arduino/pull/3647
Fixes https://github.com/arduino-libraries/SD/issues/39

Discussion here:
https://groups.google.com/a/arduino.cc/d/msg/developers/jWsi7A_g-Mk/Q2sFpzDDBQAJ
