### PR TITLE
Fixed comparisons with (wrong) unsigned-to-signed integer promotions

### DIFF
--- a/src/utility/Sd2Card.cpp
+++ b/src/utility/Sd2Card.cpp
@@ -248,7 +248,7 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   errorCode_ = inBlock_ = partialBlockRead_ = type_ = 0;
   chipSelectPin_ = chipSelectPin;
   // 16-bit init start time allows over a minute
-  uint16_t t0 = (uint16_t)millis();
+  uint16_t t0 = millis();
   uint32_t arg;
 
   // set pin modes
@@ -288,7 +288,8 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
 
   // command to go idle in SPI mode
   while ((status_ = cardCommand(CMD0, 0)) != R1_IDLE_STATE) {
-    if (((uint16_t)(millis() - t0)) > SD_INIT_TIMEOUT) {
+    uint16_t d = millis() - t0;
+    if (d > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_CMD0);
       goto fail;
     }
@@ -310,7 +311,8 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
 
   while ((status_ = cardAcmd(ACMD41, arg)) != R1_READY_STATE) {
     // check for timeout
-    if (((uint16_t)(millis() - t0)) > SD_INIT_TIMEOUT) {
+    uint16_t d = millis() - t0;
+    if (d > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_ACMD41);
       goto fail;
     }
@@ -543,10 +545,12 @@ uint8_t Sd2Card::setSpiClock(uint32_t clock)
 // wait for card to go not busy
 uint8_t Sd2Card::waitNotBusy(uint16_t timeoutMillis) {
   uint16_t t0 = millis();
+  uint16_t d;
   do {
     if (spiRec() == 0XFF) return true;
+    d = millis() - t0;
   }
-  while (((uint16_t)millis() - t0) < timeoutMillis);
+  while (d < timeoutMillis);
   return false;
 }
 //------------------------------------------------------------------------------
@@ -554,7 +558,8 @@ uint8_t Sd2Card::waitNotBusy(uint16_t timeoutMillis) {
 uint8_t Sd2Card::waitStartBlock(void) {
   uint16_t t0 = millis();
   while ((status_ = spiRec()) == 0XFF) {
-    if (((uint16_t)millis() - t0) > SD_READ_TIMEOUT) {
+    uint16_t d = millis() - t0;
+    if (d > SD_READ_TIMEOUT) {
       error(SD_CARD_ERROR_READ_TIMEOUT);
       goto fail;
     }


### PR DESCRIPTION
The following snippet demonstrates the problem:

```
  uint32_t millis0 = 0x5FFF0;
  uint32_t millis1 = 0x60010;
  uint16_t t0 = millis0;
  Serial.println((uint16_t)millis1-t0);   // prints -65504 WRONG
  Serial.println((uint16_t)(millis1-t0)); // prints 32     OK
```

the subtraction promotes each of the operands to signed integers so we must make sure that the cast is made after the operation.

To further simplify this logic and avoid this kind of subtle traps the operation has been moved from the condition into a variable of the desired size:

```
  uint16_t d = millis1 - t0;
  Serial.println(d); // prints 32 as well
```

Fix #41

/cc @SodaqMoja
