### PR TITLE
Fix: Somehow Software SPI mode for Mega Arduinos was broken

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -353,7 +353,9 @@ boolean SDClass::begin(uint32_t clock, uint8_t csPin) {
   if(root.isOpen()) root.close();
 
   return card.init(SPI_HALF_SPEED, csPin) &&
+#ifdef USE_SPI_LIB
          card.setSpiClock(clock) &&
+#endif
          volume.init(card) &&
          root.openRoot(volume);
 }

--- a/src/utility/Sd2Card.cpp
+++ b/src/utility/Sd2Card.cpp
@@ -17,7 +17,6 @@
  * along with the Arduino Sd2Card Library.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-#define USE_SPI_LIB
 #include <Arduino.h>
 #include "Sd2Card.h"
 //------------------------------------------------------------------------------

--- a/src/utility/Sd2Card.h
+++ b/src/utility/Sd2Card.h
@@ -45,6 +45,11 @@ uint8_t const SPI_QUARTER_SPEED = 2;
  * but many SD cards will fail with GPS Shield V1.0.
  */
 #define MEGA_SOFT_SPI 0
+
+#if MEGA_SOFT_SPI
+#undef USE_SPI_LIB
+#endif
+
 //------------------------------------------------------------------------------
 #if MEGA_SOFT_SPI && (defined(__AVR_ATmega1280__)||defined(__AVR_ATmega2560__))
 #define SOFTWARE_SPI

--- a/src/utility/Sd2Card.h
+++ b/src/utility/Sd2Card.h
@@ -45,14 +45,10 @@ uint8_t const SPI_QUARTER_SPEED = 2;
  * but many SD cards will fail with GPS Shield V1.0.
  */
 #define MEGA_SOFT_SPI 0
-
-#if MEGA_SOFT_SPI
-#undef USE_SPI_LIB
-#endif
-
 //------------------------------------------------------------------------------
 #if MEGA_SOFT_SPI && (defined(__AVR_ATmega1280__)||defined(__AVR_ATmega2560__))
 #define SOFTWARE_SPI
+#undef USE_SPI_LIB
 #endif  // MEGA_SOFT_SPI
 //------------------------------------------------------------------------------
 // SPI pin definitions


### PR DESCRIPTION
My 2.8" TFT Modul shield with ILI9341 driver didn't worked as expected, the SD Card Slot was not connected by HW SPI pins ( shield is made for UNO ) so i had to take Software SPI pins to make it work on my Mega 2560, that's how i stumbled across that bug, after set MEGA_SOFT_SPI to 1, everything now works.

Tested with Arduino IDE 1.8.5 