### PR TITLE
Fix a compiler warning for uninitialized 'pathidx' variable

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -403,6 +403,7 @@ SdFile SDClass::getParentDir(const char *filepath, int *index) {
     subdir->close();
     if (! subdir->open(parent, subdirname, O_READ)) {
       // failed to open one of the subdirectories
+      *index = 0;
       return SdFile();
     }
     // move forward to the next subdirectory


### PR DESCRIPTION
`SD.cpp:456:12: warning: 'pathidx' may be used uninitialized in this function [-Wmaybe-uninitialized]`
`SD.cpp:450:7: note: 'pathidx' was declared here`
