### PR TITLE
Fixes leak on creation/destruction of temporary objects

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,41 @@
+#
+# Some common rules
+#
+.*
+*.o
+#*.a
+#*.s
+*.ko
+*.so
+*.so.dbg
+*.i
+*.lst
+*.symtypes
+*.gz
+*.bz2
+*.lzma
+*.xz
+*.lz4
+*.lzo
+*.patch
+
+core
+core.*
+
+#
+# Backup files
+#
+*.orig
+*~
+\#*#
+
+#
+# python
+#
+*.pyc
+
+#
+# git files that we don't want to ignore even it they are dot-files
+#
+!.gitignore
+

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -18,31 +18,36 @@
    uint8_t nfilecount=0;
 */
 
-File::File(SdFile f, const char *n)
+File::File(const SdFile &f, const char *n)
+:Stream()
+, _file(f)
+, _name()
 {
-  // oh man you are kidding me, new() doesnt exist? Ok we do it by hand!
-  _file = (SdFile *) malloc(sizeof(SdFile));
-  if (_file) {
-    memcpy(_file, &f, sizeof(SdFile));
-
-    strncpy(_name, n, 12);
-    _name[12] = 0;
-
-    /* for debugging file open/close leaks
-       nfilecount++;
-       Serial.print("Created \"");
-       Serial.print(n);
-       Serial.print("\": ");
-       Serial.println(nfilecount, DEC);
-     */
-  }
+  strncpy(_name, n, 12);
+  _name[12] = 0;
+  /* for debugging file open/close leaks
+     nfilecount++;
+     Serial.print("Created \"");
+     Serial.print(n);
+     Serial.print("\": ");
+     Serial.println(nfilecount, DEC);
+   */
 }
 
 File::File(void)
+:Stream()
+, _file()
+, _name()
 {
-  _file = 0;
   _name[0] = 0;
   //Serial.print("Created empty file object");
+}
+
+File::~File(void)
+{
+  close();
+  //Serial.print(F("Destructor called for file "));
+  //Serial.println(_name);
 }
 
 // returns a pointer to the file name
@@ -54,7 +59,7 @@ char *File::name(void)
 // a directory is a special type of file
 boolean File::isDirectory(void)
 {
-  return (_file && _file->isDir());
+  return _file.isDir();
 }
 
 size_t File::write(uint8_t val)
@@ -65,13 +70,10 @@ size_t File::write(uint8_t val)
 size_t File::write(const uint8_t * buf, size_t size)
 {
   size_t t;
-  if (!_file) {
-    setWriteError();
-    return 0;
-  }
-  _file->clearWriteError();
-  t = _file->write(buf, size);
-  if (_file->getWriteError()) {
+
+  _file.clearWriteError();
+  t = _file.write(buf, size);
+  if (_file.getWriteError()) {
     setWriteError();
     return 0;
   }
@@ -80,35 +82,26 @@ size_t File::write(const uint8_t * buf, size_t size)
 
 int File::peek()
 {
-  if (!_file)
-    return 0;
-
-  int c = _file->read();
-  if (c != -1)
-    _file->seekCur(-1);
+  int c = _file.read();
+  if (c != -1) {
+    _file.seekCur(-1);
+  }
   return c;
 }
 
 int File::read()
 {
-  if (_file)
-    return _file->read();
-  return -1;
+  return _file.read();
 }
 
 // buffered read for more efficient, high speed reading
 int File::read(void *buf, uint16_t nbyte)
 {
-  if (_file)
-    return _file->read(buf, nbyte);
-  return 0;
+  return _file.read(buf, nbyte);
 }
 
 int File::available()
 {
-  if (!_file)
-    return 0;
-
   uint32_t n = size() - position();
 
   return n > 0X7FFF ? 0X7FFF : n;
@@ -116,51 +109,35 @@ int File::available()
 
 void File::flush()
 {
-  if (_file)
-    _file->sync();
+  _file.sync();
 }
 
 boolean File::seek(uint32_t pos)
 {
-  if (!_file)
-    return false;
-
-  return _file->seekSet(pos);
+  return _file.seekSet(pos);
 }
 
 uint32_t File::position()
 {
-  if (!_file)
-    return -1;
-  return _file->curPosition();
+  return _file.curPosition();
 }
 
 uint32_t File::size()
 {
-  if (!_file)
-    return 0;
-  return _file->fileSize();
+  return _file.fileSize();
 }
 
 void File::close()
 {
-  if (_file) {
-    _file->close();
-    free(_file);
-    _file = 0;
-
-    /* for debugging file open/close leaks
-       nfilecount--;
-       Serial.print("Deleted ");
-       Serial.println(nfilecount, DEC);
-     */
-  }
+  _file.close();
+  /* for debugging file open/close leaks
+     nfilecount--;
+     Serial.print("Deleted ");
+     Serial.println(nfilecount, DEC);
+   */
 }
 
-File::operator bool()
+File::operator  bool()
 {
-  if (_file)
-    return _file->isOpen();
-  return false;
+  return _file.isOpen();
 }
-

--- a/src/File.cpp
+++ b/src/File.cpp
@@ -18,47 +18,52 @@
    uint8_t nfilecount=0;
 */
 
-File::File(SdFile f, const char *n) {
+File::File(SdFile f, const char *n)
+{
   // oh man you are kidding me, new() doesnt exist? Ok we do it by hand!
-  _file = (SdFile *)malloc(sizeof(SdFile)); 
+  _file = (SdFile *) malloc(sizeof(SdFile));
   if (_file) {
     memcpy(_file, &f, sizeof(SdFile));
-    
+
     strncpy(_name, n, 12);
     _name[12] = 0;
-    
+
     /* for debugging file open/close leaks
        nfilecount++;
        Serial.print("Created \"");
        Serial.print(n);
        Serial.print("\": ");
        Serial.println(nfilecount, DEC);
-    */
+     */
   }
 }
 
-File::File(void) {
+File::File(void)
+{
   _file = 0;
   _name[0] = 0;
   //Serial.print("Created empty file object");
 }
 
 // returns a pointer to the file name
-char *File::name(void) {
+char *File::name(void)
+{
   return _name;
 }
 
 // a directory is a special type of file
-boolean File::isDirectory(void) {
+boolean File::isDirectory(void)
+{
   return (_file && _file->isDir());
 }
 
-
-size_t File::write(uint8_t val) {
+size_t File::write(uint8_t val)
+{
   return write(&val, 1);
 }
 
-size_t File::write(const uint8_t *buf, size_t size) {
+size_t File::write(const uint8_t * buf, size_t size)
+{
   size_t t;
   if (!_file) {
     setWriteError();
@@ -73,74 +78,89 @@ size_t File::write(const uint8_t *buf, size_t size) {
   return t;
 }
 
-int File::peek() {
-  if (! _file) 
+int File::peek()
+{
+  if (!_file)
     return 0;
 
   int c = _file->read();
-  if (c != -1) _file->seekCur(-1);
+  if (c != -1)
+    _file->seekCur(-1);
   return c;
 }
 
-int File::read() {
-  if (_file) 
+int File::read()
+{
+  if (_file)
     return _file->read();
   return -1;
 }
 
 // buffered read for more efficient, high speed reading
-int File::read(void *buf, uint16_t nbyte) {
-  if (_file) 
+int File::read(void *buf, uint16_t nbyte)
+{
+  if (_file)
     return _file->read(buf, nbyte);
   return 0;
 }
 
-int File::available() {
-  if (! _file) return 0;
+int File::available()
+{
+  if (!_file)
+    return 0;
 
   uint32_t n = size() - position();
 
   return n > 0X7FFF ? 0X7FFF : n;
 }
 
-void File::flush() {
+void File::flush()
+{
   if (_file)
     _file->sync();
 }
 
-boolean File::seek(uint32_t pos) {
-  if (! _file) return false;
+boolean File::seek(uint32_t pos)
+{
+  if (!_file)
+    return false;
 
   return _file->seekSet(pos);
 }
 
-uint32_t File::position() {
-  if (! _file) return -1;
+uint32_t File::position()
+{
+  if (!_file)
+    return -1;
   return _file->curPosition();
 }
 
-uint32_t File::size() {
-  if (! _file) return 0;
+uint32_t File::size()
+{
+  if (!_file)
+    return 0;
   return _file->fileSize();
 }
 
-void File::close() {
+void File::close()
+{
   if (_file) {
     _file->close();
-    free(_file); 
+    free(_file);
     _file = 0;
 
     /* for debugging file open/close leaks
-    nfilecount--;
-    Serial.print("Deleted ");
-    Serial.println(nfilecount, DEC);
-    */
+       nfilecount--;
+       Serial.print("Deleted ");
+       Serial.println(nfilecount, DEC);
+     */
   }
 }
 
-File::operator bool() {
-  if (_file) 
-    return  _file->isOpen();
+File::operator bool()
+{
+  if (_file)
+    return _file->isOpen();
   return false;
 }
 

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -562,7 +562,7 @@ File SDClass::open(char *filepath, uint8_t mode) {
     dir_t p;
 
     //Serial.print("\t\treading dir...");
-    while (_file->readDir(&p) > 0) {
+    while (_file.readDir(&p) > 0) {
 
       // done if past last used entry
       if (p.name[0] == DIR_NAME_FREE) {
@@ -582,7 +582,7 @@ File SDClass::open(char *filepath, uint8_t mode) {
       // print file name with possible blank fill
       SdFile f;
       char name[13];
-      _file->dirName(p, name);
+      _file.dirName(p, name);
       //Serial.print("try to open file ");
       //Serial.println(name);
 
@@ -601,7 +601,7 @@ File SDClass::open(char *filepath, uint8_t mode) {
 
   void File::rewindDirectory(void) {
     if (isDirectory())
-      _file->rewind();
+      _file.rewind();
   }
 
   SDClass SD;

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -438,7 +438,7 @@ namespace SDLib {
 
      */
 
-    int pathidx;
+    int pathidx = 0;
 
     // do the interative search
     SdFile parentdir = getParentDir(filepath, &pathidx);

--- a/src/SD.h
+++ b/src/SD.h
@@ -27,12 +27,13 @@ namespace SDLib {
 
   class File:public Stream {
         private:
+    SdFile _file; // underlying file object
     char _name[13]; // our name
-    SdFile *_file;  // underlying file pointer
 
         public:
-     File(SdFile f, const char *name);  // wraps an underlying SdFile
-     File(void);  // 'empty' constructor
+    File(const SdFile & f, const char *name);  // wraps an underlying SdFile
+    File(void);  // 'empty' constructor
+    virtual ~ File();  // destructor
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t * buf, size_t size);
     virtual int read();

--- a/src/SD.h
+++ b/src/SD.h
@@ -25,90 +25,98 @@
 
 namespace SDLib {
 
-class File : public Stream {
- private:
-  char _name[13]; // our name
-  SdFile *_file;  // underlying file pointer
+  class File:public Stream {
+        private:
+    char _name[13]; // our name
+    SdFile *_file;  // underlying file pointer
 
-public:
-  File(SdFile f, const char *name);     // wraps an underlying SdFile
-  File(void);      // 'empty' constructor
-  virtual size_t write(uint8_t);
-  virtual size_t write(const uint8_t *buf, size_t size);
-  virtual int read();
-  virtual int peek();
-  virtual int available();
-  virtual void flush();
-  int read(void *buf, uint16_t nbyte);
-  boolean seek(uint32_t pos);
-  uint32_t position();
-  uint32_t size();
-  void close();
-  operator bool();
-  char * name();
+        public:
+     File(SdFile f, const char *name);  // wraps an underlying SdFile
+     File(void);  // 'empty' constructor
+    virtual size_t write(uint8_t);
+    virtual size_t write(const uint8_t * buf, size_t size);
+    virtual int read();
+    virtual int peek();
+    virtual int available();
+    virtual void flush();
+    int read(void *buf, uint16_t nbyte);
+    boolean seek(uint32_t pos);
+    uint32_t position();
+    uint32_t size();
+    void close();
+    operator bool();
+    char *name();
 
-  boolean isDirectory(void);
-  File openNextFile(uint8_t mode = O_RDONLY);
-  void rewindDirectory(void);
-  
-  using Print::write;
-};
+    boolean isDirectory(void);
+    File openNextFile(uint8_t mode = O_RDONLY);
+    void rewindDirectory(void);
 
-class SDClass {
+    using Print::write;
+  };
 
-private:
-  // These are required for initialisation and use of sdfatlib
-  Sd2Card card;
-  SdVolume volume;
-  SdFile root;
-  
-  // my quick&dirty iterator, should be replaced
-  SdFile getParentDir(const char *filepath, int *indx);
-public:
-  // This needs to be called to set up the connection to the SD card
-  // before other methods are used.
-  boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN);
-  boolean begin(uint32_t clock, uint8_t csPin);
-  
-  //call this when a card is removed. It will allow you to insert and initialise a new card.
-  void end();
+  class SDClass {
 
-  // Open the specified file/directory with the supplied mode (e.g. read or
-  // write, etc). Returns a File object for interacting with the file.
-  // Note that currently only one file can be open at a time.
-  File open(const char *filename, uint8_t mode = FILE_READ);
-  File open(const String &filename, uint8_t mode = FILE_READ) { return open( filename.c_str(), mode ); }
+        private:
+    // These are required for initialisation and use of sdfatlib
+    Sd2Card card;
+    SdVolume volume;
+    SdFile root;
 
-  // Methods to determine if the requested file path exists.
-  boolean exists(const char *filepath);
-  boolean exists(const String &filepath) { return exists(filepath.c_str()); }
+    // my quick&dirty iterator, should be replaced
+    SdFile getParentDir(const char *filepath, int *indx);
+        public:
+    // This needs to be called to set up the connection to the SD card
+    // before other methods are used.
+     boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN);
+    boolean begin(uint32_t clock, uint8_t csPin);
 
-  // Create the requested directory heirarchy--if intermediate directories
-  // do not exist they will be created.
-  boolean mkdir(const char *filepath);
-  boolean mkdir(const String &filepath) { return mkdir(filepath.c_str()); }
-  
-  // Delete the file.
-  boolean remove(const char *filepath);
-  boolean remove(const String &filepath) { return remove(filepath.c_str()); }
-  
-  boolean rmdir(const char *filepath);
-  boolean rmdir(const String &filepath) { return rmdir(filepath.c_str()); }
+    //call this when a card is removed. It will allow you to insert and initialise a new card.
+    void end();
 
-private:
+    // Open the specified file/directory with the supplied mode (e.g. read or
+    // write, etc). Returns a File object for interacting with the file.
+    // Note that currently only one file can be open at a time.
+    File open(const char *filename, uint8_t mode = FILE_READ);
+    File open(const String & filename, uint8_t mode = FILE_READ) {
+      return open(filename.c_str(), mode);
+    }
+    // Methods to determine if the requested file path exists.
+        boolean exists(const char *filepath);
+    boolean exists(const String & filepath) {
+      return exists(filepath.c_str());
+    }
+    // Create the requested directory heirarchy--if intermediate directories// do not exist they will be created.
+        boolean mkdir(const char *filepath);
+    boolean mkdir(const String & filepath) {
+      return mkdir(filepath.c_str());
+    }
 
-  // This is used to determine the mode used to open a file
-  // it's here because it's the easiest place to pass the 
-  // information through the directory walking function. But
-  // it's probably not the best place for it.
-  // It shouldn't be set directly--it is set via the parameters to `open`.
-  int fileOpenMode;
-  
-  friend class File;
-  friend boolean callback_openPath(SdFile&, const char *, boolean, void *); 
-};
+    // Delete the file.
+    boolean remove(const char *filepath);
+    boolean remove(const String & filepath) {
+      return remove(filepath.c_str());
+    }
 
-extern SDClass SD;
+    boolean rmdir(const char *filepath);
+    boolean rmdir(const String & filepath) {
+      return rmdir(filepath.c_str());
+    }
+
+        private:
+
+    // This is used to determine the mode used to open a file
+    // it's here because it's the easiest place to pass the 
+    // information through the directory walking function. But
+    // it's probably not the best place for it.
+    // It shouldn't be set directly--it is set via the parameters to `open`.
+    int fileOpenMode;
+
+    friend class File;
+    friend boolean callback_openPath(SdFile &, const char *,
+             boolean, void *);
+  };
+
+  extern SDClass SD;
 
 };
 
@@ -120,7 +128,7 @@ using namespace SDLib;
 
 // This allows sketches to use SDLib::File with other libraries (in the
 // sketch you must use SDFile instead of File to disambiguate)
-typedef SDLib::File    SDFile;
+typedef SDLib::File SDFile;
 typedef SDLib::SDClass SDFileSystemClass;
 #define SDFileSystem   SDLib::SD
 

--- a/src/utility/SdFat.h
+++ b/src/utility/SdFat.h
@@ -137,7 +137,19 @@ uint16_t const FAT_DEFAULT_TIME = (1 << 11);
 class SdFile : public Print {
  public:
   /** Create an instance of SdFile. */
-  SdFile(void) : type_(FAT_FILE_TYPE_CLOSED) {}
+  SdFile(void)
+  : flags_(0)
+  , type_(FAT_FILE_TYPE_CLOSED)
+  , curCluster_(0)
+  , curPosition_(0)
+  , dirBlock_(0)
+  , dirIndex_(0)
+  , fileSize_(0)
+  , firstCluster_(0)
+  , vol_(0)
+  {}
+
+  virtual ~SdFile() {}
   /**
    * writeError is set to true if an error occurs during a write().
    * Set writeError to false before calling print() and/or write() and check


### PR DESCRIPTION
When temporary File() objects are created, the programmer is not able to call close(). That made the SD library leak memory. To fix it properly, not only must we supply a destructor calling close(), but we must also not use a pointer to a SdFile, because the pointer gets copied to other objects (e.g. on a call to open()), and when this temporary object gets destructed, the buffer of the newly created object gets freed. This pull request fixes this issue.