### PR TITLE
Add initalization for MMC cards.

### DIFF
--- a/src/utility/Sd2Card.cpp
+++ b/src/utility/Sd2Card.cpp
@@ -250,6 +250,7 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   // 16-bit init start time allows over a minute
   unsigned int t0 = millis();
   uint32_t arg;
+  bool useCmd1 = false;
 
   // set pin modes
   pinMode(chipSelectPin_, OUTPUT);
@@ -309,13 +310,18 @@ uint8_t Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   // initialize card and send host supports SDHC if SD2
   arg = type() == SD_CARD_TYPE_SD2 ? 0X40000000 : 0;
 
-  while ((status_ = cardAcmd(ACMD41, arg)) != R1_READY_STATE) {
+  status_ = cardAcmd(ACMD41, arg);
+  while (status_ != R1_READY_STATE) {
     // check for timeout
-    unsigned int d = millis() - t0;
-    if (d > SD_INIT_TIMEOUT) {
+    if (((uint16_t)millis() - t0) > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_ACMD41);
       goto fail;
     }
+    // Switch to CMD1 if the card fails to recognize ACMD41
+    if (status_ & R1_ILLEGAL_COMMAND) {
+      useCmd1 = true;
+    }
+    status_ = (!useCmd1 ? cardAcmd(ACMD41, arg) : cardCommand(CMD1, 0));
   }
   // if SD2 read OCR register to check for SDHC card
   if (type() == SD_CARD_TYPE_SD2) {

--- a/src/utility/SdInfo.h
+++ b/src/utility/SdInfo.h
@@ -34,6 +34,8 @@
 // SD card commands
 /** GO_IDLE_STATE - init card in spi mode if CS low */
 uint8_t const CMD0 = 0X00;
+/** SEND_OP_COND - Initiate initialization process (used for MMC card) */
+uint8_t const CMD1 = 0x01;
 /** SEND_IF_COND - verify SD Memory Card interface operating condition.*/
 uint8_t const CMD8 = 0X08;
 /** SEND_CSD - read the Card Specific Data (CSD register) */


### PR DESCRIPTION
This commit includes 'hacks' described [here](http://blog.damnsoft.org/arduino-sd-library-support-for-mmc-cards/#mmc_problem)
Without it library is not able to initalize MMC card.