### PR TITLE
Use correct include syntax

### DIFF
--- a/src/SD.h
+++ b/src/SD.h
@@ -17,8 +17,8 @@
 
 #include <Arduino.h>
 
-#include <utility/SdFat.h>
-#include <utility/SdFatUtil.h>
+#include "utility/SdFat.h"
+#include "utility/SdFatUtil.h"
 
 #define FILE_READ O_READ
 #define FILE_WRITE (O_READ | O_WRITE | O_CREAT | O_APPEND)

--- a/src/utility/SdFat.h
+++ b/src/utility/SdFat.h
@@ -28,7 +28,7 @@
 #endif
 #include "Sd2Card.h"
 #include "FatStructs.h"
-#include "Print.h"
+#include <Print.h>
 //------------------------------------------------------------------------------
 /**
  * Allow use of deprecated functions if non-zero


### PR DESCRIPTION
Angle brackets for external includes. Quotes for local includes. The former is not critical but the latter is necessary in order to use the library when it's not in one of the standard Arduino libraries folders (such as when bundled with a sketch), where local files included with the angle brackets syntax will not be found in the include search path, causing compilation to fail.