### PR TITLE
Update arduino-cli binary filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   - wget http://downloads.arduino.cc/arduino-cli/arduino-cli-$CLI_VERSION-linux64.tar.bz2
   - tar xf arduino-cli-$CLI_VERSION-linux64.tar.bz2
   - mkdir -p "$HOME/bin"
-  - mv arduino-cli-*-linux64 $HOME/bin/arduino-cli
+  - mv arduino-cli "$HOME/bin"
   - export PATH="$PATH:$HOME/bin"
   - arduino-cli core update-index
   - buildExampleSketch() { arduino-cli compile --verbose --warnings all --fqbn $BOARD "$PWD/examples/$1"; }


### PR DESCRIPTION
The arduino-cli binary filename was recently changed, which broke CI builds:
```
mv: cannot stat ‘arduino-cli-*-linux64’: No such file or directory
```