### PR TITLE
Fixes location of high card size bits in V2.00 CSD

### DIFF
--- a/src/utility/SdInfo.h
+++ b/src/utility/SdInfo.h
@@ -190,8 +190,8 @@ typedef struct CSDV2 {
   unsigned write_blk_misalign : 1;
   unsigned read_bl_partial : 1;
   // byte 7
-  unsigned reserved3 : 2;
   unsigned c_size_high : 6;
+  unsigned reserved3 : 2;
   // byte 8
   uint8_t c_size_mid;
   // byte 9


### PR DESCRIPTION
This fixes a bug where the size of large cards was reported incorrectly by `struct CSDV2`/`csd2_t`.

The SD card size is encoded in 22 bits in the V2.00 CSD block. Due to the way bits are numbered in the spec and C bitfields are laid out on little-endian systems, the 6-bit `c_size_high` field must be listed before the `reserved3` dummy field to include the low 6 bits of the byte.

This bug only affected cards over 32GiB in size, as the `c_size_high` field is zero on smaller cards anyway.