### PR TITLE
Fix card size with CSD v2.00

### DIFF
--- a/src/utility/Sd2Card.cpp
+++ b/src/utility/Sd2Card.cpp
@@ -164,7 +164,7 @@ uint32_t Sd2Card::cardSize(void) {
     return (uint32_t)(c_size + 1) << (c_size_mult + read_bl_len - 7);
   } else if (csd.v2.csd_ver == 1) {
     uint32_t c_size = ((uint32_t)csd.v2.c_size_high << 16)
-                      | (csd.v2.c_size_mid << 8) | csd.v2.c_size_low;
+                      | ((uint32_t)csd.v2.c_size_mid << 8) | csd.v2.c_size_low;
     return (c_size + 1) << 10;
   } else {
     error(SD_CARD_ERROR_BAD_CSD);

--- a/src/utility/SdInfo.h
+++ b/src/utility/SdInfo.h
@@ -190,8 +190,8 @@ typedef struct CSDV2 {
   unsigned write_blk_misalign : 1;
   unsigned read_bl_partial : 1;
   // byte 7
-  unsigned reserved3 : 2;
   unsigned c_size_high : 6;
+  unsigned reserved3 : 2;
   // byte 8
   uint8_t c_size_mid;
   // byte 9


### PR DESCRIPTION
Fix position of "c_size_high" in struct "csd2_t" and cast 8 bits variable ("csd.v2.c_size_mid") to allow left shift by 8 in cardSize() method.