### PR TITLE
Update ReadWrite.ino

### DIFF
--- a/examples/ReadWrite/ReadWrite.ino
+++ b/examples/ReadWrite/ReadWrite.ino
@@ -41,7 +41,7 @@ void setup() {
     Serial.println("Note: press reset or reopen this serial monitor after fixing your issue!");
     while (1);
   }
-  
+
   Serial.println("initialization done.");
 
   // open the file. note that only one file can be open at a time,

--- a/examples/ReadWrite/ReadWrite.ino
+++ b/examples/ReadWrite/ReadWrite.ino
@@ -34,9 +34,14 @@ void setup() {
   Serial.print("Initializing SD card...");
 
   if (!SD.begin(4)) {
-    Serial.println("initialization failed!");
+    Serial.println("initialization failed. Things to check:");
+    Serial.println("1. is a card inserted?");
+    Serial.println("2. is your wiring correct?");
+    Serial.println("3. did you change the chipSelect pin to match your shield or module?");
+    Serial.println("Note: press reset or reopen this serial monitor after fixing your issue!");
     while (1);
   }
+  
   Serial.println("initialization done.");
 
   // open the file. note that only one file can be open at a time,

--- a/src/utility/SdFat.h
+++ b/src/utility/SdFat.h
@@ -41,17 +41,17 @@ class SdVolume;
 // SdFile class
 
 #ifdef O_RDONLY //ARDUINO_ARCH_MBED
-#undef O_READ
-#undef O_RDONLY
-#undef O_WRITE
-#undef O_WRONLY
-#undef O_RDWR
-#undef O_ACCMODE
-#undef O_APPEND
-#undef O_SYNC
-#undef O_CREAT
-#undef O_EXCL
-#undef O_TRUNC
+  #undef O_READ
+  #undef O_RDONLY
+  #undef O_WRITE
+  #undef O_WRONLY
+  #undef O_RDWR
+  #undef O_ACCMODE
+  #undef O_APPEND
+  #undef O_SYNC
+  #undef O_CREAT
+  #undef O_EXCL
+  #undef O_TRUNC
 #endif
 
 // flags for ls()


### PR DESCRIPTION
There is an incompatibility issue for showing the initialization error message for the examples.

The example `CardInfo.ino` has this code (which i personally like)
```
if (!card.init(SPI_HALF_SPEED, chipSelect)) {
    Serial.println("initialization failed. Things to check:");
    Serial.println("* is a card inserted?");
    Serial.println("* is your wiring correct?");
    Serial.println("* did you change the chipSelect pin to match your shield or module?");
    while (1);
  } else {
    Serial.println("Wiring is correct and a card is present.");
  }
```

While the other example, like the `ReadWrite.ino` uses this code
```
if (!SD.begin(4)) {
    Serial.println("initialization failed!");
    while (1);
  }
  Serial.println("initialization done.");
```
It's a better idea to make one function in the library for doing this instead of writing similar code in all the examples. I will work on updating the library code if others agree with me on this :)