### PR TITLE
corrected typo in msg printed when SD Card fails to initialize

### DIFF
--- a/examples/CardInfo/CardInfo.ino
+++ b/examples/CardInfo/CardInfo.ino
@@ -52,6 +52,7 @@ void setup() {
     Serial.println("* is a card inserted?");
     Serial.println("* is your wiring correct?");
     Serial.println("* did you change the chipSelect pin to match your shield or module?");
+    Serial.println("Note: press reset button on the board and reopen this Serial Monitor after fixing your issue!");
     while (1);
   } else {
     Serial.println("Wiring is correct and a card is present.");

--- a/examples/Datalogger/Datalogger.ino
+++ b/examples/Datalogger/Datalogger.ino
@@ -41,7 +41,7 @@ void setup() {
     Serial.println("1. is a card inserted?");
     Serial.println("2. is your wiring correct?");
     Serial.println("3. did you change the chipSelect pin to match your shield or module?");
-    Serial.println("Note: press reset or reopen this Serial Monitor after fixing your issue!");
+    Serial.println("Note: press reset button on the board and reopen this Serial Monitor after fixing your issue!");
     while (true);
   }
 

--- a/examples/DumpFile/DumpFile.ino
+++ b/examples/DumpFile/DumpFile.ino
@@ -38,7 +38,7 @@ void setup() {
     Serial.println("1. is a card inserted?");
     Serial.println("2. is your wiring correct?");
     Serial.println("3. did you change the chipSelect pin to match your shield or module?");
-    Serial.println("Note: press reset or reopen this Serial Monitor after fixing your issue!");
+    Serial.println("Note: press reset button on the board and reopen this Serial Monitor after fixing your issue!");
     while (true);
   }
 

--- a/examples/Files/Files.ino
+++ b/examples/Files/Files.ino
@@ -33,7 +33,11 @@ while (!Serial);
   Serial.print("Initializing SD card...");
 
   if (!SD.begin(chipSelect)) {
-    Serial.println("initialization failed!");
+    Serial.println("initialization failed. Things to check:");
+    Serial.println("1. is a card inserted?");
+    Serial.println("2. is your wiring correct?");
+    Serial.println("3. did you change the chipSelect pin to match your shield or module?");
+    Serial.println("Note: press reset button on the board and reopen this serial monitor after fixing your issue!");
     while (1);
   }
   Serial.println("initialization done.");

--- a/examples/NonBlockingWrite/NonBlockingWrite.ino
+++ b/examples/NonBlockingWrite/NonBlockingWrite.ino
@@ -64,7 +64,7 @@ void setup() {
     Serial.println("1. is a card inserted?");
     Serial.println("2. is your wiring correct?");
     Serial.println("3. did you change the chipSelect pin to match your shield or module?");
-    Serial.println("Note: press reset or reopen this Serial Monitor after fixing your issue!");
+    Serial.println("Note: press reset button on the board and reopen this Serial Monitor after fixing your issue!");
     while (true);
   }
 

--- a/examples/ReadWrite/ReadWrite.ino
+++ b/examples/ReadWrite/ReadWrite.ino
@@ -36,7 +36,7 @@ void setup() {
     Serial.println("1. is a card inserted?");
     Serial.println("2. is your wiring correct?");
     Serial.println("3. did you change the chipSelect pin to match your shield or module?");
-    Serial.println("Note: press reset or reopen this Serial Monitor after fixing your issue!");
+    Serial.println("Note: press reset button on the board and reopen this Serial Monitor after fixing your issue!");
     while (true);
   }
 

--- a/examples/listfiles/listfiles.ino
+++ b/examples/listfiles/listfiles.ino
@@ -44,7 +44,7 @@ void setup() {
     Serial.println("1. is a card inserted?");
     Serial.println("2. is your wiring correct?");
     Serial.println("3. did you change the chipSelect pin to match your shield or module?");
-    Serial.println("Note: press reset or reopen this Serial Monitor after fixing your issue!");
+    Serial.println("Note: press reset button on the board and reopen this Serial Monitor after fixing your issue!");
     while (true);
   }
 


### PR DESCRIPTION
Hello,
This PR fixes a typo in the message printed by Serial.print() when the SD card fails to initialize that can misguide new users. 

This fixes an issue #78 


@per1234 Please review.

Thank you. 
