### PR TITLE
Reading spaces in the filename

### DIFF
--- a/src/utility/SdFile.cpp
+++ b/src/utility/SdFile.cpp
@@ -315,7 +315,7 @@ uint8_t SdFile::make83Name(const char* str, uint8_t* name) {
         }
       #endif
       // check size and only allow ASCII printable characters
-      if (i > n || c < 0X21 || c > 0X7E) {
+      if (i > n || c <= 0X21 || c >= 0X7F) {
         return false;
       }
       // only upper case allowed in 8.3 names - convert lower to upper


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/intl/character-sets-used-in-file-names

According to the article above though Windows now supports NTFS format, the SD card still uses FAT format. Some character was added, I hope this solves the issue #3 