### PR TITLE
Add support for the rest of the megaAVR-0 chips

### DIFF
--- a/src/utility/Sd2PinMap.h
+++ b/src/utility/Sd2PinMap.h
@@ -31,7 +31,10 @@
 
 #endif // Sd2PinMap_h
 
-#elif defined(__AVR_ATmega4809__) // Arduino UNO WiFI Rev2 follows
+#elif defined(__AVR_ATmega4809__) || defined(__AVR_ATmega4808__) || \
+defined(__AVR_ATmega3209__) || defined(__AVR_ATmega3208__) || \
+defined(__AVR_ATmega1609__) || defined(__AVR_ATmega1608__) || \
+defined(__AVR_ATmega809__) || defined(__AVR_ATmega808__)
 
 #ifndef Sd2PinMap_h
   #define Sd2PinMap_h


### PR DESCRIPTION
There's no reason why this library can't be used with other megaAVR-0 chips than the ATmega4809.
ATmega4808, ATmega3209/3208, ATmega1609/1608 and ATmega809/808 are supported in Arduino IDE using [MegaCoreX](https://github.com/MCUdude/MegaCoreX).