### PR TITLE
Fixes leak on creation/destruction of temporary objects

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -586,7 +586,7 @@ namespace SDLib {
     dir_t p;
 
     //Serial.print("\t\treading dir...");
-    while (_file->readDir(&p) > 0) {
+    while (_file.readDir(&p) > 0) {
 
       // done if past last used entry
       if (p.name[0] == DIR_NAME_FREE) {
@@ -609,7 +609,7 @@ namespace SDLib {
       // print file name with possible blank fill
       SdFile f;
       char name[13];
-      _file->dirName(p, name);
+      _file.dirName(p, name);
       //Serial.print("try to open file ");
       //Serial.println(name);
 
@@ -628,7 +628,7 @@ namespace SDLib {
 
   void File::rewindDirectory(void) {
     if (isDirectory()) {
-      _file->rewind();
+      _file.rewind();
     }
   }
 

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -453,7 +453,7 @@ namespace SDLib {
 
     */
 
-    int pathidx;
+    int pathidx = 0;
 
     // do the interactive search
     SdFile parentdir = getParentDir(filepath, &pathidx);

--- a/src/SD.h
+++ b/src/SD.h
@@ -28,11 +28,12 @@ namespace SDLib {
   class File : public Stream {
     private:
       char _name[13]; // our name
-      SdFile *_file;  // underlying file pointer
+      SdFile _file;   // underlying file object
 
     public:
-      File(SdFile f, const char *name);     // wraps an underlying SdFile
+      File(const SdFile & f, const char *name); // wraps an underlying SdFile
       File(void);      // 'empty' constructor
+      virtual ~File(); // destructor
       virtual size_t write(uint8_t);
       virtual size_t write(const uint8_t *buf, size_t size);
       virtual int availableForWrite();
@@ -46,7 +47,7 @@ namespace SDLib {
       uint32_t size();
       void close();
       operator bool();
-      char * name();
+      char *name();
 
       bool isDirectory(void);
       File openNextFile(uint8_t mode = O_RDONLY);

--- a/src/utility/SdFat.h
+++ b/src/utility/SdFat.h
@@ -151,7 +151,19 @@ uint16_t const FAT_DEFAULT_TIME = (1 << 11);
 class SdFile : public Print {
   public:
     /** Create an instance of SdFile. */
-    SdFile(void) : type_(FAT_FILE_TYPE_CLOSED) {}
+    SdFile(void)
+    : flags_(0)
+    , type_(FAT_FILE_TYPE_CLOSED)
+    , curCluster_(0)
+    , curPosition_(0)
+    , dirBlock_(0)
+    , dirIndex_(0)
+    , fileSize_(0)
+    , firstCluster_(0)
+    , vol_(0)
+    {}
+
+    virtual ~SdFile() {}
     /**
        writeError is set to true if an error occurs during a write().
        Set writeError to false before calling print() and/or write() and check


### PR DESCRIPTION
When temporary File() objects are created, the programmer is not able to call close(). That made the SD library leak memory. To fix it properly, not only must we supply a destructor calling close(), but we must also not use a pointer to a SdFile, because the pointer gets copied to other objects (e.g. on a call to open()), and when this temporary object gets destructed, the buffer of the newly created object gets freed. This pull request fixes this issue.