### PR TITLE
Fixed openNextFile() speed in case of large directories.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,4 +10,4 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 The SD library allows for reading from and writing to SD cards.
 
 For more information about this library please visit us at
-http://www.arduino.cc/en/Reference/repository-name}
+http://www.arduino.cc/en/Reference/{repository-name}

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=SD
 version=1.2.4
-author=Arduino, SparkFun
+author=Arduino, SparkFun, Sanyi
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables reading and writing on SD cards. 
 paragraph=Once an SD memory card is connected to the SPI interface of the Arduino board you can create files and read/write on them. You can also move through directories on the SD card.

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -587,7 +587,7 @@ namespace SDLib {
 
     //Serial.print("\t\treading dir...");
     while (_file->readDir(&p) > 0) {
-
+      uint16_t index = (_file->curPosition() - sizeof(dir_t) ) >> 5;
       // done if past last used entry
       if (p.name[0] == DIR_NAME_FREE) {
         //Serial.println("end");
@@ -607,14 +607,14 @@ namespace SDLib {
       }
 
       // print file name with possible blank fill
-      SdFile f;
-      char name[13];
-      _file->dirName(p, name);
       //Serial.print("try to open file ");
       //Serial.println(name);
 
-      if (f.open(_file, name, mode)) {
+      SdFile f;
+      if (f.open(_file, index, mode)) {
         //Serial.println("OK!");
+        char name[13];
+        _file->dirName(p, name);
         return File(f, name);
       } else {
         //Serial.println("ugh");


### PR DESCRIPTION
In case of large directories the SD::openNextFile() iterates through the files and opens them one by one. It calls SdFile::open() by name, so the open() method also iterates through the directory until it finds the selected file.
Instead let's keed track the directory index (position within the directory) and open the file by this index.
This speeds up the iteration on large directories dramatically.

Also a typo is fixed in the README.adoc. From the author, you shall remove my name.