### PR TITLE
Speed up listing files in large directory, README.adoc typo fixed

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,4 +10,4 @@ image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/
 The SD library allows for reading from and writing to SD cards.
 
 For more information about this library please visit us at
-http://www.arduino.cc/en/Reference/repository-name}
+http://www.arduino.cc/en/Reference/{repository-name}

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -587,7 +587,6 @@ namespace SDLib {
 
     //Serial.print("\t\treading dir...");
     while (_file->readDir(&p) > 0) {
-
       // done if past last used entry
       if (p.name[0] == DIR_NAME_FREE) {
         //Serial.println("end");
@@ -607,14 +606,16 @@ namespace SDLib {
       }
 
       // print file name with possible blank fill
-      SdFile f;
-      char name[13];
-      _file->dirName(p, name);
       //Serial.print("try to open file ");
       //Serial.println(name);
 
-      if (f.open(_file, name, mode)) {
+      SdFile f;
+      uint16_t index = (_file->curPosition() - sizeof(dir_t) ) >> 5;
+
+      if (f.open(_file, index, mode)) {
         //Serial.println("OK!");
+        char name[13];
+        _file->dirName(p, name);
         return File(f, name);
       } else {
         //Serial.println("ugh");


### PR DESCRIPTION
When calling the ::openNextFile(), it iterates though the current directory one by one and when it find a usable return value (file or directory) tried to create a new SdFile instance by name which scans the whole directory again for that file. Though the entry is already found by the openNextFile().
Index is calculated based on current file position and SdFile is created based on index.