### PR TITLE
support all new chips, not just megaAVR 0-series

### DIFF
--- a/src/utility/Sd2PinMap.h
+++ b/src/utility/Sd2PinMap.h
@@ -31,10 +31,7 @@
 
 #endif // Sd2PinMap_h
 
-#elif defined(__AVR_ATmega4809__) || defined(__AVR_ATmega4808__) || \
-defined(__AVR_ATmega3209__) || defined(__AVR_ATmega3208__) || \
-defined(__AVR_ATmega1609__) || defined(__AVR_ATmega1608__) || \
-defined(__AVR_ATmega809__) || defined(__AVR_ATmega808__)
+#elif defined(__AVR_ARCH__) && (__AVR_ARCH__ == 102 || __AVR_ARCH__  == 103 || __AVR_ARCH__ == 104)
 
 #ifndef Sd2PinMap_h
   #define Sd2PinMap_h


### PR DESCRIPTION
This change has been tested in megaTinyCore and DxCore. This simple change adds compatibility with all tinyAVR 0/1/2-series parts, Dx-series including the future DD-series, and anything else Microchip is likely to release in the foreseeable futire all without breaking compatibility with megaAVR 0-series. 
`__AVR_ARCH__ `=103 for all tinyAVR 0/1/2-series and megaAVR 0-series (103 is "all modern AVRs where the flash is fully memory mapped"), as well as 32k Dx-series. 102 is 64k modern AVRs which thus don't have all of their flash memory mapped, (so it catches the AVR64Dx parts), and 104 s 128k modern AVRs for the all important AVR128Dx parts.