### PR TITLE
expose card and volume objects allowing for interface to tinyUSB

### DIFF
--- a/src/SD.h
+++ b/src/SD.h
@@ -106,6 +106,14 @@ namespace SDLib {
         return rmdir(filepath.c_str());
       }
 
+      Sd2Card& getCard() {
+        return card;
+      }
+
+      SdVolume& getVolume() {
+        return volume;
+      }
+
     private:
 
       // This is used to determine the mode used to open a file


### PR DESCRIPTION
This small change exposes references to the card and volume objects in SDClass. 

This allows for a deeper integration with Arduino's TinyUSB disk interface that would not normally be possible. See the Adafruit TinyUSB Library Examples > Mass Storage > msc_sd source code.  By exposing the card and volume objects, one can re-express this interface using core SDClass as the interface point -- instead of resorting to separate card and volume instances as is shown in this example.  This makes it possible to have concurrent file-level interactions in the Arduino code while exposing the SD card to a host via the TinyUSB disk interface.