### PR TITLE
Format demo code in reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -669,29 +669,29 @@ void loop() {
 }
 
 void printDirectory(File dir, int numTabs) {
-   while(true) {
+  while (true) {
 
-     File entry =  dir.openNextFile();
-     if (! entry) {
-       // No more files
-       // Serial.println("**nomorefiles**");
-       break;
-     }
+    File entry = dir.openNextFile();
+    if (!entry) {
+      // No more files
+      // Serial.println("**nomorefiles**");
+      break;
+    }
 
-     for (uint8_t i=0; i<numTabs; i++) {
-       Serial.print('\t');
-     }
+    for (uint8_t i = 0; i < numTabs; i++) {
+      Serial.print('\t');
+    }
 
-     Serial.print(entry.name());
-     if (entry.isDirectory()) {
-       Serial.println("/");
-       printDirectory(entry, numTabs+1);
-     } else {
-       // Files have sizes, directories do not
-       Serial.print("\t\t");
-       Serial.println(entry.size(), DEC);
-     }
-   }
+    Serial.print(entry.name());
+    if (entry.isDirectory()) {
+      Serial.println("/");
+      printDirectory(entry, numTabs + 1);
+    } else {
+      // Files have sizes, directories do not
+      Serial.print("\t\t");
+      Serial.println(entry.size(), DEC);
+    }
+  }
 }
 ```
 
@@ -745,7 +745,7 @@ void setup() {
   delay(2000);
 
   Serial.println();
-  Serial.println("Rewinding, and repeating below:" );
+  Serial.println("Rewinding, and repeating below:");
   Serial.println();
   delay(2000);
 
@@ -761,7 +761,7 @@ void loop() {
 void printDirectory(File dir, int numTabs) {
   while (true) {
     File entry = dir.openNextFile();
-    if (! entry) {
+    if (!entry) {
       if (numTabs == 0)
         Serial.println("** Done **");
       return;
@@ -841,29 +841,29 @@ void loop() {
 }
 
 void printDirectory(File dir, int numTabs) {
-   while(true) {
-     File entry =  dir.openNextFile();
-     if (! entry) {
-       // No more files
-       // Return to the first file in the directory
-       dir.rewindDirectory();
-       break;
-     }
+  while (true) {
+    File entry = dir.openNextFile();
+    if (!entry) {
+      // No more files
+      // Return to the first file in the directory
+      dir.rewindDirectory();
+      break;
+    }
 
-     for (uint8_t i=0; i<numTabs; i++) {
-       Serial.print('\t');
-     }
+    for (uint8_t i = 0; i < numTabs; i++) {
+      Serial.print('\t');
+    }
 
-     Serial.print(entry.name());
-     if (entry.isDirectory()) {
-       Serial.println("/");
-       printDirectory(entry, numTabs+1);
-     } else {
-       // Files have sizes, directories do not
-       Serial.print("\t\t");
-       Serial.println(entry.size(), DEC);
-     }
-   }
+    Serial.print(entry.name());
+    if (entry.isDirectory()) {
+      Serial.println("/");
+      printDirectory(entry, numTabs + 1);
+    } else {
+      // Files have sizes, directories do not
+      Serial.print("\t\t");
+      Serial.println(entry.size(), DEC);
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Some of the library reference pages provide code demonstrating usage. In some places, this code had a very odd formatting where the first indent was three spaces, followed by the standard two space indent for the rest. This made the structure of the code difficult to follow and also results in an unexpected diff when the user runs the formatter on the code in Arduino IDE or Web Editor. It also makes it unfriendly to contributors.

All code in the reference is hereby formatted to be compliant with the [Arduino IDE 2.x](https://github.com/arduino/arduino-ide) auto formatter (which uses [a configuration](https://github.com/arduino/arduino-language-server/blob/0.6.0/ls/ls_formatter.go#L15-L160) equivalent that of the formatters in Arduino IDE 1.x and Arduino Web Editor).