### PR TITLE
Make `File::rewindDirectory` reference demo code more clear

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -833,6 +833,7 @@ void setup() {
   SD.begin(10);
   root = SD.open("/");
   printDirectory(root, 0);
+  root.rewindDirectory();  // Return to the first file in the directory
   Serial.println("Done!");
 }
 
@@ -845,8 +846,6 @@ void printDirectory(File dir, int numTabs) {
     File entry = dir.openNextFile();
     if (!entry) {
       // No more files
-      // Return to the first file in the directory
-      dir.rewindDirectory();
       break;
     }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -833,7 +833,13 @@ void setup() {
   SD.begin(10);
   root = SD.open("/");
   printDirectory(root, 0);
+  Serial.println();
+
+  Serial.println("PRINT AGAIN");
+  Serial.println("-----------");
   root.rewindDirectory();  // Return to the first file in the directory
+  printDirectory(root, 0);
+
   Serial.println("Done!");
 }
 


### PR DESCRIPTION
The reference page for `File::rewindDirectory` provides a sketch demonstrating its usage.

Feedback was received that the code did not clearly demonstrate the use and effect of the function: https://github.com/arduino/Arduino/issues/11734

@PaulStoffregen suggested several changes to improve on that situation. An atomic subset of those are proposed here:

- Avoid unnecessary calls of `File::rewindDirectory`: https://github.com/arduino-libraries/SD/commit/615568f44e89b1bc7c4b330b736921aef8f159d6
- Print the card file structure twice: https://github.com/arduino-libraries/SD/commit/55cd20fec7f169e63f6323845d4916d5d923d79f

---

Resolves (partially) https://github.com/arduino/Arduino/issues/11734