### PR TITLE
Replace irrelevant function name in `File::println` docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -451,7 +451,7 @@ Print data, followed by a carriage return and newline, to the File, which must h
 ```
 file.println()
 file.println(data)
-file.print(data, BASE)
+file.println(data, BASE)
 ```
 
 #### Parameters


### PR DESCRIPTION
A copy/paste error resulted in one of the items under the "Syntax" section of the documentation for `File::println` using the function name `print` instead of the intended `println`.

Fixes https://github.com/arduino/Arduino/issues/11211