### PR TITLE
Add patch for software SPI support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,5 +12,5 @@ The SD library allows for reading from and writing to SD cards.
 For more information about this library please visit us at
 http://www.arduino.cc/en/Reference/{repository-name}
 
-Added patch to adapt library for TFT shield on Arduino Mega
+Added patch to adapt library for TFT shield on Arduino Mega. Description of the changes at
 https://www.aranacorp.com/fr/utilisation-du-module-sd-du-shield-tft-avec-arduino-mega/

--- a/README.adoc
+++ b/README.adoc
@@ -11,3 +11,6 @@ The SD library allows for reading from and writing to SD cards.
 
 For more information about this library please visit us at
 http://www.arduino.cc/en/Reference/{repository-name}
+
+Added patch to adapt library for TFT shield on Arduino Mega
+https://www.aranacorp.com/fr/utilisation-du-module-sd-du-shield-tft-avec-arduino-mega/

--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -354,7 +354,7 @@ namespace SDLib {
            volume.init(card) &&
            root.openRoot(volume);
   }
-
+#ifndef SOFTWARE_SPI //Added compiler directive so that MEGA works with this code
   bool SDClass::begin(uint32_t clock, uint8_t csPin) {
     if (root.isOpen()) {
       root.close();
@@ -365,7 +365,19 @@ namespace SDLib {
            volume.init(card) &&
            root.openRoot(volume);
   }
+#else
+  bool SDClass::begin(uint32_t clock, uint8_t csPin) {
+    if (root.isOpen()) {
+      root.close();
+    }
 
+    return card.init(SPI_HALF_SPEED, csPin) &&
+           card.setSpiClock(clock) &&
+           volume.init(card) &&
+           root.openRoot(volume);
+  }
+#endif  //SOFTWARE_SPI
+  
   //call this when a card is removed. It will allow you to insert and initialise a new card.
   void SDClass::end() {
     root.close();

--- a/src/utility/Sd2Card.cpp
+++ b/src/utility/Sd2Card.cpp
@@ -17,11 +17,12 @@
    along with the Arduino Sd2Card Library.  If not, see
    <http://www.gnu.org/licenses/>.
 */
-#define USE_SPI_LIB
+//#define USE_SPI_LIB //moved line 25
 #include <Arduino.h>
 #include "Sd2Card.h"
 //------------------------------------------------------------------------------
 #ifndef SOFTWARE_SPI
+#define USE_SPI_LIB
 #ifdef USE_SPI_LIB
 
   #ifndef SDCARD_SPI

--- a/src/utility/Sd2Card.h
+++ b/src/utility/Sd2Card.h
@@ -35,7 +35,7 @@ uint8_t const SPI_QUARTER_SPEED = 2;
    USE_SPI_LIB: if set, use the SPI library bundled with Arduino IDE, otherwise
    run with a standalone driver for AVR.
 */
-#define USE_SPI_LIB
+//#define USE_SPI_LIB //moved line 56
 /**
    Define MEGA_SOFT_SPI non-zero to use software SPI on Mega Arduinos.
    Pins used are SS 10, MOSI 11, MISO 12, and SCK 13.
@@ -53,6 +53,7 @@ uint8_t const SPI_QUARTER_SPEED = 2;
 // SPI pin definitions
 //
 #ifndef SOFTWARE_SPI
+   #define USE_SPI_LIB
   // hardware pin defs
 
   // include pins_arduino.h or variant.h depending on architecture, via Arduino.h


### PR DESCRIPTION
Sd2Card.h line 38: #define USE_SPI_LIB moved to line 56
Sd2Card.cpp line 20: #define USE_SPI_LIB moved to line 25
SD.cpp line 357 in function SDClass::begin(uint32_t clock, uint8_t csPin), remove card.setSpiClock(clock) when SOFTWARE_SPI is defined

Description of the changes here
https://www.aranacorp.com/fr/utilisation-du-module-sd-du-shield-tft-avec-arduino-mega/