### PR TITLE
Initialized integer

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -455,7 +455,7 @@ namespace SDLib {
 
     */
 
-    int pathidx;
+    int pathidx = 0;
 
     // do the interactive search
     SdFile parentdir = getParentDir(filepath, &pathidx);


### PR DESCRIPTION
Just simple fix - initialized integer to avoid warning. No effect on functionality

**Warning:**
`SD.cpp:462:14: warning: 'pathidx' may be used uninitialized in this function [-Wmaybe-uninitialized]
     filepath += pathidx;
              ^
SD.cpp:456:9: note: 'pathidx' was declared here
     int pathidx;`

IDE 2.0.1 with enabled all compiler warnings