### PR TITLE
Fix spell check false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ,
+ignore-words-list = indx
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
The "codespell" tool is used to check for commonly misspelled words in the project files.

As part of a recent update, "indx" was added to the misspelled words dictionary as a misspelling of "index". The project contains a variable named "indx", so the spell check started failing following that update. Although it is questionable whether using a variable name that is shortened from the related correct word by only a single letter, it is also not objectively wrong. Since it is believed that this was an intentional choice by the developer, the spell check failure can be considered spurious. In this case, the correct resolution is to configure codespell to ignore this word.